### PR TITLE
Add option to save to bytes / load from buffers

### DIFF
--- a/tests/SymSpellCppPyTest.py
+++ b/tests/SymSpellCppPyTest.py
@@ -559,6 +559,23 @@ class SymSpellCppPyTests(unittest.TestCase):
                          sym_spell_2.lookup("flam", Verbosity.TOP, 0, True)[0].term)
         os.remove(pickle_path)
 
+    def test_pickle_bytes(self):
+        edit_distance_max = 2
+        prefix_length = 7
+
+        sym_spell = SymSpell(edit_distance_max, prefix_length)
+        sym_spell.create_dictionary_entry("test", 123)
+        sym_spell.create_dictionary_entry("ball", 4)
+        sym_spell.create_dictionary_entry("code", 56)
+        sym_bytes = sym_spell.save_pickle_bytes()
+
+        sym_spell_ld = SymSpell(edit_distance_max, prefix_length)
+        sym_spell_ld.load_pickle_bytes(sym_bytes)
+
+        self.assertEqual("test", sym_spell_ld.lookup("tst", Verbosity.CLOSEST)[0].term)
+        self.assertEqual("ball", sym_spell_ld.lookup("boll", Verbosity.CLOSEST)[0].term)
+        self.assertEqual(2, sym_spell_ld.lookup("c0d3", Verbosity.CLOSEST)[0].distance)
+
     def test_delete_dictionary_entry(self):
         sym_spell = SymSpell()
         sym_spell.create_dictionary_entry("stea", 1)


### PR DESCRIPTION
Added `save_pickle_bytes`, which saves the contents to a `bytes` object, and, `load_pickle_bytes`, which loads from any object implementing the buffer protocol (such as bytes, memoryview, numpy arrays, etc), as long as the buffer is contiguous and one dimensional. Also created a test for those functions.

Those functions are useful to be able to store the SymSpell along with other structures on a single file.