### PR TITLE
Check if deletes is null to avoid seg fault

### DIFF
--- a/library.cpp
+++ b/library.cpp
@@ -27,7 +27,7 @@ namespace symspellcpppy {
     }
 
     int SymSpell::EntryCount() {
-        return deletes->size();
+        return deletes == nullptr ? 0 : deletes->size();
     }
 
     SymSpell::SymSpell(int _maxDictionaryEditDistance, int _prefixLength, int _countThreshold, int _initialCapacity,
@@ -288,6 +288,8 @@ namespace symspellcpppy {
     std::vector<SuggestItem>
     SymSpell::Lookup(xstring input, Verbosity verbosity, int maxEditDistance, bool includeUnknown,
                      bool transferCasing) {
+        if (deletes == nullptr) return {}; // Dictionary is empty
+
         int skip = 0;
         xstring original_phrase;
         if (maxEditDistance > maxDictionaryEditDistance) throw std::invalid_argument("Distance too large");

--- a/tests/SymSpellCppPyTest.py
+++ b/tests/SymSpellCppPyTest.py
@@ -736,6 +736,9 @@ class SymSpellCppPyTests(unittest.TestCase):
                                   transfer_casing=True)
         self.assertEqual("I", result[0].term)
 
+    def test_empty_deletes(self):
+        self.assertEqual(SymSpell(2).lookup("ab", Verbosity.CLOSEST), [])
+        self.assertEqual(SymSpell().entry_count(), 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If the SymSpell object was empty and I tried to lookup on it, I was getting a segmentation fault.
I simply added some checks if deletes is null on Lookup and EntryCount to avoid such cases.

Below is an example that crashes before this update:

```python3
from SymSpellCppPy import SymSpell, Verbosity

SymSpell(2).lookup("ab", Verbosity.CLOSEST)  # crashes with segmentation fault
SymSpell().entry_count()  # also crashes with segmentation fault
```