### PR TITLE
Avoid copying xstrings at most cases

### DIFF
--- a/SymSpellCppPy.cpp
+++ b/SymSpellCppPy.cpp
@@ -118,20 +118,20 @@ PYBIND11_MODULE(SymSpellCppPy, m) {
                  py::arg("corpus"))
             .def("purge_below_threshold_words", &symspellcpppy::SymSpell::PurgeBelowThresholdWords,
                  "Remove all below threshold words from the dictionary.")
-            .def("lookup", py::overload_cast<xstring, symspellcpppy::Verbosity>(
+            .def("lookup", py::overload_cast<const xstring &, symspellcpppy::Verbosity>(
                     &symspellcpppy::SymSpell::Lookup),
                  " Find suggested spellings for a given input word, using the maximum\n"
                  "    edit distance specified during construction of the SymSpell dictionary.",
                  py::arg("input"),
                  py::arg("verbosity"))
-            .def("lookup", py::overload_cast<xstring, symspellcpppy::Verbosity, int>(
+            .def("lookup", py::overload_cast<const xstring &, symspellcpppy::Verbosity, int>(
                     &symspellcpppy::SymSpell::Lookup),
                  " Find suggested spellings for a given input word, using the maximum\n"
                  "    edit distance provided to the function.",
                  py::arg("input"),
                  py::arg("verbosity"),
                  py::arg("max_edit_distance"))
-            .def("lookup", py::overload_cast<xstring, symspellcpppy::Verbosity, int, bool>(
+            .def("lookup", py::overload_cast<const xstring &, symspellcpppy::Verbosity, int, bool>(
                     &symspellcpppy::SymSpell::Lookup),
                  " Find suggested spellings for a given input word, using the maximum\n"
                  "    edit distance provided to the function and include input word in suggestions, if no words within edit distance found.",
@@ -139,7 +139,7 @@ PYBIND11_MODULE(SymSpellCppPy, m) {
                  py::arg("verbosity"),
                  py::arg("max_edit_distance"),
                  py::arg("include_unknown"))
-            .def("lookup", py::overload_cast<xstring, symspellcpppy::Verbosity, int, bool, bool>(
+            .def("lookup", py::overload_cast<const xstring &, symspellcpppy::Verbosity, int, bool, bool>(
                     &symspellcpppy::SymSpell::Lookup),
                  " Find suggested spellings for a given input word, using the maximum\n"
                  "    edit distance provided to the function and include input word in suggestions, if no words within edit distance found & preserve transfer casing.",

--- a/include/BaseDistance.h
+++ b/include/BaseDistance.h
@@ -10,7 +10,7 @@
 
 class BaseDistance {
 public:
-    virtual double Distance(xstring string1, xstring string2) = 0;
+    virtual double Distance(const xstring& string1, const xstring& string2) = 0;
 
-    virtual double Distance(xstring string1, xstring string2, double maxDistance) = 0;
+    virtual double Distance(const xstring& string1, const xstring& string2, double maxDistance) = 0;
 };

--- a/include/BaseSimilarity.h
+++ b/include/BaseSimilarity.h
@@ -9,7 +9,7 @@
 
 class BaseSimilarity {
 public:
-    virtual double Similarity(xstring string1, xstring string2) = 0;
+    virtual double Similarity(const xstring& string1, const xstring& string2) = 0;
 
-    virtual double Similarity(xstring string1, xstring string2, double minSimilarity) = 0;
+    virtual double Similarity(const xstring& string1, const xstring& string2, double minSimilarity) = 0;
 };

--- a/include/DamerauOSA.h
+++ b/include/DamerauOSA.h
@@ -26,42 +26,37 @@ public:
         basePrevChar1Costs = std::vector<int>(expectedMaxstringLength, 0);
     }
 
-    double Distance(xstring string1, xstring string2) override {
+    double Distance(const xstring& string1, const xstring& string2) override {
         if (string1.empty()) return string2.size();
         if (string2.empty()) return string1.size();
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return len2;
 
         if (len2 > baseChar1Costs.size()) {
             baseChar1Costs = std::vector<int>(len2, 0);
             basePrevChar1Costs = std::vector<int>(len2, 0);
         }
-        return Distance(string1, string2, len1, len2, start, baseChar1Costs, basePrevChar1Costs);
+        return Distance(str1, str2, len1, len2, start, baseChar1Costs, basePrevChar1Costs);
     }
 
-    double Distance(xstring string1, xstring string2, double maxDistance) override {
+    double Distance(const xstring& string1, const xstring& string2, double maxDistance) override {
         if (string1.empty() || string2.empty()) return Helpers::NullDistanceResults(string1, string2, maxDistance);
         if (maxDistance <= 0) return (string1 == string2) ? 0 : -1;
         maxDistance = ceil(maxDistance);
         int iMaxDistance = (maxDistance <= INT_MAX) ? (int) maxDistance : INT_MAX;
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
-        if (string2.size() - string1.size() > iMaxDistance) return -1;
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
+
+        if (str2.size() - str1.size() > iMaxDistance) return -1;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return (len2 <= iMaxDistance) ? len2 : -1;
 
         if (len2 > baseChar1Costs.size()) {
@@ -69,50 +64,44 @@ public:
             basePrevChar1Costs = std::vector<int>(len2, 0);
         }
         if (iMaxDistance < len2) {
-            return Distance(string1, string2, len1, len2, start, iMaxDistance, baseChar1Costs, basePrevChar1Costs);
+            return Distance(str1, str2, len1, len2, start, iMaxDistance, baseChar1Costs, basePrevChar1Costs);
         }
-        return Distance(string1, string2, len1, len2, start, baseChar1Costs, basePrevChar1Costs);
+        return Distance(str1, str2, len1, len2, start, baseChar1Costs, basePrevChar1Costs);
     }
 
-    double Similarity(xstring string1, xstring string2) override {
+    double Similarity(const xstring& string1, const xstring& string2) override {
         if (string1.empty()) return (string2.empty()) ? 1 : 0;
         if (string2.empty()) return 0;
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return 1.0;
 
         if (len2 > baseChar1Costs.size()) {
             baseChar1Costs = std::vector<int>(len2, 0);
             basePrevChar1Costs = std::vector<int>(len2, 0);
         }
-        return Helpers::ToSimilarity(Distance(string1, string2, len1, len2, start, baseChar1Costs, basePrevChar1Costs),
-                                     string2.size());
+        return Helpers::ToSimilarity(Distance(str1, str2, len1, len2, start, baseChar1Costs, basePrevChar1Costs),
+                                     str2.size());
     }
 
-    double Similarity(xstring string1, xstring string2, double minSimilarity) override {
+    double Similarity(const xstring& string1, const xstring& string2, double minSimilarity) override {
         if (minSimilarity < 0 || minSimilarity > 1)
             throw std::invalid_argument("minSimilarity must be in range 0 to 1.0");
         if (string1.empty() || string2.empty()) return Helpers::NullSimilarityResults(string1, string2, minSimilarity);
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
 
-        int iMaxDistance = Helpers::ToDistance(minSimilarity, string2.size());
-        if (string2.size() - string1.size() > iMaxDistance) return -1;
-        if (iMaxDistance <= 0) return (string1 == string2) ? 1 : -1;
+        int iMaxDistance = Helpers::ToDistance(minSimilarity, str2.size());
+        if (str2.size() - str1.size() > iMaxDistance) return -1;
+        if (iMaxDistance <= 0) return (str1 == str2) ? 1 : -1;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return 1.0;
 
         if (len2 > baseChar1Costs.size()) {
@@ -121,16 +110,16 @@ public:
         }
         if (iMaxDistance < len2) {
             return Helpers::ToSimilarity(
-                    Distance(string1, string2, len1, len2, start, iMaxDistance, baseChar1Costs, basePrevChar1Costs),
-                    string2.size());
+                    Distance(str1, str2, len1, len2, start, iMaxDistance, baseChar1Costs, basePrevChar1Costs),
+                    str2.size());
         }
-        return Helpers::ToSimilarity(Distance(string1, string2, len1, len2, start, baseChar1Costs, basePrevChar1Costs),
-                                     string2.size());
+        return Helpers::ToSimilarity(Distance(str1, str2, len1, len2, start, baseChar1Costs, basePrevChar1Costs),
+                                     str2.size());
     }
 
     static int
-    Distance(xstring string1, xstring string2, int len1, int len2, int start, std::vector<int> char1Costs,
-             std::vector<int> prevChar1Costs) {
+    Distance(const xstring& string1, const xstring& string2, int len1, int len2, int start, std::vector<int>& char1Costs,
+             std::vector<int>& prevChar1Costs) {
         int j;
         for (j = 0; j < len2; j++) char1Costs[j] = j + 1;
         xchar char1 = XL(' ');
@@ -166,8 +155,8 @@ public:
         return currentCost;
     }
 
-    static int Distance(xstring string1, xstring string2, int len1, int len2, int start, int maxDistance,
-                        std::vector<int> char1Costs, std::vector<int> prevChar1Costs) {
+    static int Distance(const xstring& string1, const xstring& string2, int len1, int len2, int start, int maxDistance,
+                        std::vector<int>& char1Costs, std::vector<int>& prevChar1Costs) {
         int i, j;
         for (j = 0; j < maxDistance; j++)
             char1Costs[j] = j + 1;

--- a/include/Helpers.h
+++ b/include/Helpers.h
@@ -45,7 +45,7 @@ public:
         return (string1.empty() && string2.empty()) ? 1 : (0 <= minSimilarity) ? 0 : -1;
     }
 
-    static void PrefixSuffixPrep(xstring string1, xstring string2, int &len1, int &len2, int &start) {
+    static void PrefixSuffixPrep(const xstring& string1, const xstring& string2, int &len1, int &len2, int &start) {
         len2 = string2.size();
         len1 = string1.size(); // this is also the minimum length of the two strings
         // suffix common to both strings can be ignored
@@ -79,13 +79,13 @@ public:
             return -1;
     }
 
-    static xstring string_lower(xstring a) {
+    static xstring string_lower(const xstring& a) {
         xstring a_lower = a;
         std::transform(a.begin(), a.end(), a_lower.begin(), to_xlower);
         return a_lower;
     }
 
-    static xstring string_upper(xstring a) {
+    static xstring string_upper(const xstring& a) {
         xstring a_upper = a;
         std::transform(a.begin(), a.end(), a_upper.begin(), to_xupper);
         return a_upper;

--- a/include/Levenshtein.h
+++ b/include/Levenshtein.h
@@ -26,107 +26,96 @@ public:
         baseChar1Costs = std::vector<int>(expectedMaxstringLength, 0);
     }
 
-    double Distance(xstring string1, xstring string2) override {
+    double Distance(const xstring& string1, const xstring& string2) override {
         if (string1.empty()) return string2.size();
         if (string2.empty()) return string1.size();
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return len2;
 
-        return Distance(string1, string2, len1, len2, start,
+        return Distance(str1, str2, len1, len2, start,
                         (baseChar1Costs = (len2 <= baseChar1Costs.size()) ? baseChar1Costs : std::vector<int>(len2,
                                                                                                               0)));
     }
 
-    double Distance(xstring string1, xstring string2, double maxDistance) override {
+    double Distance(const xstring& string1, const xstring& string2, double maxDistance) override {
         if (string1.empty() || string2.empty()) return Helpers::NullDistanceResults(string1, string2, maxDistance);
         if (maxDistance <= 0) return (string1 == string2) ? 0 : -1;
         maxDistance = ceil(maxDistance);
         int iMaxDistance = (maxDistance <= INT_MAX) ? (int) maxDistance : INT_MAX;
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
-        if (string2.size() - string1.size() > iMaxDistance) return -1;
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
+
+        if (str2.size() - str1.size() > iMaxDistance) return -1;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return (len2 <= iMaxDistance) ? len2 : -1;
 
         if (iMaxDistance < len2) {
-            return Distance(string1, string2, len1, len2, start, iMaxDistance,
+            return Distance(str1, str2, len1, len2, start, iMaxDistance,
                             (baseChar1Costs = (len2 <= baseChar1Costs.size()) ? baseChar1Costs : std::vector<int>(len2,
                                                                                                                   0)));
         }
-        return Distance(string1, string2, len1, len2, start,
+        return Distance(str1, str2, len1, len2, start,
                         (baseChar1Costs = (len2 <= baseChar1Costs.size()) ? baseChar1Costs : std::vector<int>(len2,
                                                                                                               0)));
     }
 
-    double Similarity(xstring string1, xstring string2) override {
+    double Similarity(const xstring& string1, const xstring& string2) override {
         if (string1.empty()) return (string2.empty()) ? 1 : 0;
         if (string2.empty()) return 0;
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return 1.0;
 
-        return Helpers::ToSimilarity(Distance(string1, string2, len1, len2, start,
+        return Helpers::ToSimilarity(Distance(str1, str2, len1, len2, start,
                                               (baseChar1Costs = (len2 <= baseChar1Costs.size()) ? baseChar1Costs
                                                                                                 : std::vector<int>(len2,
                                                                                                                    0))),
-                                     string2.size());
+                                     str2.size());
     }
 
-    double Similarity(xstring string1, xstring string2, double minSimilarity) override {
+    double Similarity(const xstring& string1, const xstring& string2, double minSimilarity) override {
         if (minSimilarity < 0 || minSimilarity > 1)
             throw std::invalid_argument("minSimilarity must be in range 0 to 1.0");
         if (string1.empty() || string2.empty()) return Helpers::NullSimilarityResults(string1, string2, minSimilarity);
 
-        if (string1.size() > string2.size()) {
-            xstring t = string1;
-            string1 = string2;
-            string2 = t;
-        }
+        const xstring& str1 = (string1.size() > string2.size()) ? string2 : string1;
+        const xstring& str2 = (string1.size() > string2.size()) ? string1 : string2;
 
-        int iMaxDistance = Helpers::ToDistance(minSimilarity, string2.size());
-        if (string2.size() - string1.size() > iMaxDistance) return -1;
-        if (iMaxDistance == 0) return (string1 == string2) ? 1 : -1;
+        int iMaxDistance = Helpers::ToDistance(minSimilarity, str2.size());
+        if (str2.size() - str1.size() > iMaxDistance) return -1;
+        if (iMaxDistance == 0) return (str1 == str2) ? 1 : -1;
 
         int len1, len2, start;
-        Helpers::PrefixSuffixPrep(string1, string2, len1, len2, start);
+        Helpers::PrefixSuffixPrep(str1, str2, len1, len2, start);
         if (len1 == 0) return 1.0;
 
         if (iMaxDistance < len2) {
-            return Helpers::ToSimilarity(Distance(string1, string2, len1, len2, start, iMaxDistance,
+            return Helpers::ToSimilarity(Distance(str1, str2, len1, len2, start, iMaxDistance,
                                                   (baseChar1Costs = (len2 <= baseChar1Costs.size()) ? baseChar1Costs
                                                                                                     : std::vector<int>(
-                                                                  len2, 0))), string2.size());
+                                                                  len2, 0))), str2.size());
         }
-        return Helpers::ToSimilarity(Distance(string1, string2, len1, len2, start,
+        return Helpers::ToSimilarity(Distance(str1, str2, len1, len2, start,
                                               (baseChar1Costs = (len2 <= baseChar1Costs.size()) ? baseChar1Costs
                                                                                                 : std::vector<int>(len2,
                                                                                                                    0))),
-                                     string2.size());
+                                     str2.size());
     }
 
     static int
-    Distance(xstring string1, xstring string2, int len1, int len2, int start, std::vector<int> &char1Costs) {
+    Distance(const xstring& string1, const xstring& string2, int len1, int len2, int start, std::vector<int> &char1Costs) {
         for (int j = 0; j < len2;) char1Costs[j] = ++j;
         int currentCharCost = 0;
         if (start == 0) {
@@ -165,7 +154,7 @@ public:
         return currentCharCost;
     }
 
-    static int Distance(xstring string1, xstring string2, int len1, int len2, int start, int maxDistance,
+    static int Distance(const xstring& string1, const xstring& string2, int len1, int len2, int start, int maxDistance,
                         std::vector<int> &char1Costs) {
         int i, j;
         for (j = 0; j < maxDistance;) char1Costs[j] = ++j;

--- a/library.h
+++ b/library.h
@@ -193,7 +193,7 @@ namespace symspellcpppy {
         /// <param name="verbosity">The value controlling the quantity/closeness of the retuned suggestions.</param>
         /// <returns>A List of SuggestItem object representing suggested correct spellings for the input word,
         /// sorted by edit distance, and secondarily by count frequency.</returns>
-        std::vector<SuggestItem> Lookup(xstring input, Verbosity verbosity);
+        std::vector<SuggestItem> Lookup(const xstring& input, Verbosity verbosity);
 
         /// <summary>Find suggested spellings for a given input word, using the maximum
         /// edit distance specified during construction of the SymSpell dictionary.</summary>
@@ -202,7 +202,7 @@ namespace symspellcpppy {
         /// <param name="maxEditDistance">The maximum edit distance between input and suggested words.</param>
         /// <returns>A List of SuggestItem object representing suggested correct spellings for the input word,
         /// sorted by edit distance, and secondarily by count frequency.</returns>
-        std::vector<SuggestItem> Lookup(xstring input, Verbosity verbosity, int maxEditDistance);
+        std::vector<SuggestItem> Lookup(const xstring& input, Verbosity verbosity, int maxEditDistance);
 
         /// <summary>Find suggested spellings for a given input word.</summary>
         /// <param name="input">The word being spell checked.</param>
@@ -211,7 +211,7 @@ namespace symspellcpppy {
         /// <param name="includeUnknown">Include input word in suggestions, if no words within edit distance found.</param>
         /// <returns>A List of SuggestItem object representing suggested correct spellings for the input word,
         /// sorted by edit distance, and secondarily by count frequency.</returns>
-        std::vector<SuggestItem> Lookup(xstring input, Verbosity verbosity, int maxEditDistance, bool includeUnknown);
+        std::vector<SuggestItem> Lookup(const xstring& input, Verbosity verbosity, int maxEditDistance, bool includeUnknown);
 
         /// <summary>Find suggested spellings for a given input word.</summary>
         /// <param name="input">The word being spell checked.</param>
@@ -221,20 +221,20 @@ namespace symspellcpppy {
         /// <param name="transfer_casing"> Lower case the word or not
         /// <returns>A List of SuggestItem object representing suggested correct spellings for the input word,
         /// sorted by edit distance, and secondarily by count frequency.</returns>
-        std::vector<SuggestItem> Lookup(xstring input, Verbosity verbosity, int maxEditDistance, bool includeUnknown, bool transferCasing);
+        std::vector<SuggestItem> Lookup(const xstring& input, Verbosity verbosity, int maxEditDistance, bool includeUnknown, bool transferCasing);
 
     private:
         bool
-        DeleteInSuggestionPrefix(xstring deleteSugg, int deleteLen, xstring suggestion, int suggestionLen) const;
+        DeleteInSuggestionPrefix(const xstring& deleteSugg, int deleteLen, xstring suggestion, int suggestionLen) const;
 
         static std::vector<xstring> ParseWords(const xstring &text);
 
         std::shared_ptr<std::unordered_set<xstring>>
         Edits(const xstring &word, int editDistance, std::shared_ptr<std::unordered_set<xstring>> deleteWords);
 
-        std::shared_ptr<std::unordered_set<xstring>> EditsPrefix(xstring key);
+        std::shared_ptr<std::unordered_set<xstring>> EditsPrefix(const xstring& key);
 
-        int GetstringHash(xstring s) const;
+        int GetstringHash(const xstring& s) const;
 
     public:
         //######################


### PR DESCRIPTION
I made some big changes to avoid copying strings and other structures.
To make it easier to understand my changes, [I added some comments to the files on the commit](https://github.com/marcoffee/SymSpellCppPy/commit/9d2a3c3fe249e80226af179991d295e39db408ba)