### PR TITLE
fix: regex parsing on clang++/MacOS fix

### DIFF
--- a/library.cpp
+++ b/library.cpp
@@ -459,7 +459,7 @@ namespace symspellcpppy {
     }
 
     std::vector<xstring> SymSpell::ParseWords(const xstring &text) {
-        xregex r(XL("['’\\w-\\[_\\]]+"));
+        xregex r(XL("['’\\w\\-\\[_\\]]+"));
         xsmatch m;
         std::vector<xstring> matches;
         xstring::const_iterator ptr(text.cbegin());

--- a/library.h
+++ b/library.h
@@ -100,7 +100,7 @@ namespace symspellcpppy {
     };
 
     class SymSpell {
-    private:
+    protected:
         int initialCapacity;
         int maxDictionaryEditDistance;
         int prefixLength; //prefix length  5..7


### PR DESCRIPTION
This PR fixes the below error message

```
RuntimeError: The expression contained an invalid character range, such as [b-a] in most encodings.
```

Signed-off-by: Rajdeep Roy Chowdhury <rajdeep.roychowdhury@lowes.com>