### PR TITLE
Add -ffat-lto-objects compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,8 @@ if (BUILD_FOR_PYTHON)
     target_sources(SymSpellCppPy PRIVATE library.cpp library.h)
     target_link_libraries(SymSpellCppPy PRIVATE SymSpellCpp)
     target_compile_options(SymSpellCppPy PRIVATE
-            $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native -mtune=native -fvisibility=hidden -flto>)
+            $<$<CONFIG:Release>:-O3 -DNDEBUG -march=native -mtune=native -fvisibility=hidden
+            -flto -ffat-lto-objects>)
     message(STATUS "Build for Python = " ${BUILD_FOR_PYTHON})
 else ()
     Include(FetchContent)


### PR DESCRIPTION
Recently, I started using `lld` as the default linker for my applications. It is a very faster replacement for the default `gold` linker, included at the binutils package.

After first compilation using `lld` as the linker, this package started giving `ImportError`s such as this one:
```python
ImportError: dynamic module does not define module export function (PyInit_SymSpellCppPy)
```

This error can be reproduced by installing `lld` and adding the following line before `target_compile_options` (currently, line 28) on `CMakeLists.txt`:
```cmake
target_link_options(SymSpellCppPy PRIVATE -fuse-ld=lld)
```

After playing a little with the compilation flags, it seems that adding the flag `-ffat-lto-objects` to `target_compile_options` on `CMakeLists.txt` fixes the problem.

This pull request addresses this issue, while keeping backward compatibility with other linkers.